### PR TITLE
Make changes to hello world and add Rust built-in type chapter..

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,9 @@
 resolver = "2"
 members = [
     "tinker",
-    "learn/*"
+    "learn/*",
 ]
 exclude = [
-    "learn/1-hello-world"
+    "learn/1-hello-world",
+    "learn/rust-builtin-types",
 ]

--- a/learn/1-hello-world/README.md
+++ b/learn/1-hello-world/README.md
@@ -19,20 +19,7 @@ hello-world
     └── main.rs
 ```
 
-> You may see a warning that the `hello-world` project is not included in the workspace. Add `"hello-world"` update the members in the `Cargo.toml` file located in the root of the project to fix this.
->
-> ```toml
-> [workspace]
-> members = [
->     "hello-world" # Add this
->     ...
-> ]
-
-The `Cargo.toml` file is the manifest file for Rust projects. It contains all the metadata for the project, as well as the dependencies.
-
-The `src` directory contains the source code of the project. The `main.rs` file is the entry point of the program. Later, we will see how to structure/create libraries and other binaries.
-
-Open the `hello-world` directory in VSCode and take a look at the `main.rs` file. It should look something like this:
+The `src` directory contains the source code of the project. The `main.rs` file is the entry point of the program. Open the `hello-world` directory in VSCode and take a look at the `main.rs` file. It should look something like this:
 
 ```rust
 fn main() {
@@ -40,11 +27,31 @@ fn main() {
 }
 ```
 
-From the terminal, you can run the following command to build and run the program:
+Rust functions are defined with the `fn` keyword and the `main` function is the default program entry point. `println!` might look like a function call, but it actually a `macro`. The key is that all `macros` end with a `!`. We'll discuss `macros` in more detail in a following chapter.
+
+From the VSCode terminal, you can run the following command to build and run the program:
 
 ```bash
 cargo run
 ```
+
+By default, `cargo run` will compile and run the `debug` (unoptimized) version of the crate. To execute the `release` version, use `cargo run --release`.
+
+Note that actual binary file resides under the `target` folder under the `debug` or `release` folder.
+
+At this point, you have successfully created your very first Rust `crate`. A `crate` can be standalone or may have dependencies on other (local or remote) crates. During the build process, `cargo` fetches and compiles the dependencies. This is conceptually equivalent to linking/importing in other languages.
+
+Execute the following command from the VSCode terminal:
+
+```bash
+cat Cargo.toml
+```
+
+The `Cargo.toml` file is the manifest file for Rust projects. It contains all the metadata for the project, as well as the dependencies.
+
+Notice that it contains a few entries under `[package]`, including the name of our executable (`hello-world`). Later, we shall see how to target other types of binary targets including static library, dynamic library (uncommon).
+
+Note that the folder also contains a file called `Cargo.lock`. It is automatically generated and should not be modified by hand. We will revisit the specific purpose of `Cargo.lock` later.
 
 ## The Compiler is your Friend
 

--- a/learn/rust-builtin-types/README.md
+++ b/learn/rust-builtin-types/README.md
@@ -1,0 +1,72 @@
+# Data Types
+
+Rust has several built-in types that are similar to their analogues in other languages.
+
+|  **Description**  |            **Type**            |          **Example**          |
+|:-----------------:|:------------------------------:|:-----------------------------:|
+| Signed integers   | i8, i16, i32, i64, i128, isize | -1, 42, 1_00_000, 1_00_000i64 |
+| Unsigned integers | u8, u16, u32, u64, u128, usize | 0, 42, 42u32, 42u64           |
+| Floating point    | f32, f64                       | 0.0, 0.42                     |
+| Unicode           | char                           | 'a', '$'                      |
+| Boolean           | bool                           | true, false                   |
+
+Notice how Rust permits arbitrarily use of `_` between numbers for ease of reading.
+
+Rust uses the `let` keyword to assign values to variables. The type of the variable can be optionally specified after a `:` or using a suffix (like `u32`, `u64` etc). If the type isn't explicitly defined, it can often be can be implicitly inteferred by the compiler using `type inference` as shown in the code snippet below.
+
+```bash
+cargo new types
+```
+
+Open the `types` folder in VSCode and replace the contents of `main.rs` with the following. Notice how the VSCode displays the inferred types.
+
+```rust
+fn main() {
+    let x : i32 = 42;
+    // Type is x1 is implicitly inferred as i32
+    let x1 = 42;
+    // These two assignments are logically equivalent
+    let y : u32 = 42;
+    let z = 42u32;
+}
+```
+
+Note that `type inference` cannot be used in function parameters or function
+return values. In Rust, functions must begin with the `fn` keyword (as seen in `fn main()` above).
+Function parameters are listed within the paranthesis `()` and must have an explicit type (specified after the parameter name with `:` separator).
+Functions may optionally return an explictly specified value that must follow `->` as shown in the code snippet below.
+
+```rust
+fn add_one(x: u32) -> u32 {
+    // This simply returns the passed in parameter as the return value from the function.
+    // We'll revisit the return statement later.
+    return x + 1;
+}
+```
+
+Let us put this together in an example to see how it all comes together. Replace the contents
+of `main.rs` with the following:
+
+```rust
+fn secret_of_life_u32(x: u32) {
+    // We'll discuss formatting in println!() later
+    println!("The u32 secret_of_life is {}", x);
+}
+
+fn secret_of_life_u8(x: u8) {
+    // We'll discuss formatting in println!() later
+    println!("The u8 secret_of_life is {}", x);
+}
+
+fn main() {
+    let a = 42; // The let keyword assigns a value
+    let b = 42; // The let keyword assigns a value
+                // Notice how the compiler uses the function signature to infer types
+                // Comment out the next two lines to see how the type of a and b changes
+    secret_of_life_u32(a);
+    secret_of_life_u8(b);
+}
+```
+Notice that when the calls to the `secret_of_life_*` are commented out, it automatically changes the inferred type of the variable. Another side effect of commenting
+the function calls is that the compiler emits a warning about the unused variables. In Rust,
+unused varibles should be prefixed with `_` to avoid this warning (try changing `a` and `b` to `_a` and `_b`).

--- a/learn/rust-control-flow-and-loops/README.md
+++ b/learn/rust-control-flow-and-loops/README.md
@@ -1,0 +1,127 @@
+# Control flow, loops, and expressions
+
+This section covers the Rust `if`, `while`, `for` and `loop` keywords.
+
+In Rust `if` behaves as a control flow statement like many other languages, but it can also be used an expression. This is best illustrated by an example.
+
+Create a new package called `controlflow` by executing `cargo new controlflow` under this folder, open `main.rs` in VSCode, and replace the default content with the following snippet.
+
+```rust
+fn main() {
+    let x = 42;
+    if x < 42 {
+        println!("Smaller than the secret of life");
+    } else if x == 42 {
+        println!("Is equal to the secret of life");
+    } else {
+        println!("Larger than the secret of life");
+    }
+    let is_secret_of_life = if x == 42 {true} else {false};
+    println!("{}", is_secret_of_life);
+}
+```
+
+Notice how the `if` in `let is_secret_of_life = if x == 42 {true} else {false};` is used as an expression that assigns a value. This is made possible by a Rust feature called `expression blocks` (more on this later).
+
+The ```while``` keyword can be used to loop while an expression is true.
+
+```rust
+fn main() {
+    let mut x = 40;
+    while x != 42 {
+        x += 1;
+    }
+}
+```
+
+The `for` keyword can be used to iterate over ranges. Unlike other languages that require a variable to define the start of a range and increment it until the end, Rust simply uses constants for the beginning and end of the range. The increment for the range is always `1`. Note that the end of the range *isn't inclusive unless* it's prefixed with a `=`. 
+
+```rust
+fn main() {
+    // Will not print 43; use in 40..=43 to include last element
+    for x in 40..43 {
+        println!("{}", x);
+    }
+}
+```
+The use of constant range in the `for` above is an application of a more general Rust concept called `iterators`. We'll discuss how to comine `for` and `iterators` in a forthcoming chapter.
+
+The Rust `loop` keyword creates an infinite loop that can be terminated by a `break` keyword.
+
+```rust
+fn main() {
+    let mut x = 40;
+     loop {
+        if x == 42 {
+            break;
+        }
+        x += 1;
+    }
+}
+```
+
+The `break` keyword can also can include an optional expression that can be used to assign the value of from ```loop```.
+
+```rust
+fn main() {
+    let mut x = 40;
+    // y will be assigned 42 when the loop terminates
+    let y = loop {
+        if x == 42 {
+            break x;
+        }
+        x += 1;
+    };
+}
+```
+
+The `continue` keyword can be used to return to the top of the `loop`. This can be combined with `loop labels` in nested loops to specify the target of the `break`. Loop labels are prefixed with a ``` ` ``` and must use a `:` suffix.
+
+```rust
+fn main() {
+    let mut x = 40;
+    'outer: loop {
+        if x+1 == 42 {
+            break;
+        }
+        loop {
+            x += 1;
+            if x == 41 {
+                // Breaks to 'outer loop
+                break 'outer;
+            } else {
+                // Silly, but continues inner loop
+                continue;
+            }
+        }
+    }
+}
+```
+
+In Rust, most keywords are *expressions* (as opposed to statements in other languages). Expression blocks are simply a sequence of expressions enclosed in `{}`. The general rule is that evaluated value is simply the last expression in the block.
+
+In preceding examples we used expression blocks with `if {true} else {false};` to assign a value, return values while breaking from loops, and so forth.
+
+Expression blocks can also be used to elide return statements from functions. The idea is that the return value of the function is simply the evaluation of last expression.
+
+```rust
+fn is_secret_of_life(x: u32) -> bool {
+    // Same as if x == 42 {true} else {false}
+    x == 42 // Note: ; must be omitted
+}
+
+fn main() {
+    println!("{}", is_secret_of_life(42));
+}
+```
+
+Note that the last expression `x == 42` evaluates to a `bool`, which matches the return type of `is_secret_of_life`. If we change the expression to `x == 42;` it will be equivalent to the following snippet:
+
+```rust
+fn is_secret_of_life(x: u32) -> bool {
+    let _ = x == 42;
+}
+```
+The `_` in the `let` assignment is a placeholder for an anonymous variable that receives the `bool` value from the expression evaluation. However, in the absence of an explicit return statement, the function now returns the `unit type` or `()` (**which will result in an informative compiler error about the mismatched return type**). The Rust `unit type` is roughly the equivalent of the `void` return type in some languages.
+
+Unless specified otherwise, the `()` is default type that's returned from from all functions, including `main()`.

--- a/learn/rust-variables/README.md
+++ b/learn/rust-variables/README.md
@@ -1,0 +1,45 @@
+# Variable immutability and shadowing
+
+One of the unique features of Rust is that variables are **immutable** by default. The `mut` keyword can be used to define a **mutable** variable.
+
+Consider the following code snippet (notice the use of `_` before the variable name to avoid the compiler warning about unused variables):
+
+```rust
+fn main() {
+    let a = 42;
+    a = 43;  // Will not compile
+}
+```
+Create a new package called `variables` by executing `cargo new variables` under this folder, open `main.rs` in VSCode, and replace the default content with the above snippet.
+
+Try to execute the program using `cargo run` from the terminal and note that the compiler will not allow the program to compile until `let a = 42` is changed to `let mut a = 42` as shown below.
+
+```rust
+fn main() {
+    let mut a = 42;
+    a = 43;  // OK
+}
+```
+Another unique feature of Rust is variable shadowing, i.e., it is possible to redefine a variable with the same name. Note that this creates a *new* variable that isn't associated with the original.
+
+```rust
+fn main() {
+    let a = 42;
+    let a = 43;  // OK; defines a new immutable variable
+    // a = 42;   // This won't compile as before
+}
+```
+Variable shadowing is permitted both within the same scope as well as a nested scope. The compiler automatically tracks the shadowing.
+
+```rust
+fn main() {
+    let a = 42; // Immutable variable
+    {
+        let mut a = 43; // Different mutable variable inside a new scope
+        a = 42; // Ok within this scope
+    }
+    // a = 42;   // This won't compile as before
+}
+```
+
+The key takeway is that immutability is a core concept in Rust and everything is *immutable* by default unless it's explicitly declared as mutable. This might appear strange since it's the exact inverse of many other languages, but the increased predictability about side effects of function calls and other operations on variables actually makes it easier to reason about code.


### PR DESCRIPTION

This adds the following crate related concepts to helloworld:

1) Release vs. Debug
2) Introduces the reader to Cargo.lock
3) Hints at additional roles for Cargo.toml

It removes:

1) The need to add the crate to a workspace. This isn't necessary and
adds to the information overload.
2) Content that talked about how the Rust compiler can be a
learning tool. This is definitely useful information, but it should be
introduced a little later since it breaks the primary flow.

The second change adds a chapter on Rust built-in types.